### PR TITLE
Add Support For Augeas Configuration API

### DIFF
--- a/plugins/COMMON/hostname/files/usr/sbin/createhs
+++ b/plugins/COMMON/hostname/files/usr/sbin/createhs
@@ -3,38 +3,76 @@ PATH="/sbin:/bin:/usr/bin"
 
 PREFIX="raspberrypi"
 
-if [ -e /var/tmp/system-hostname ]; then
-	if [ -e /etc/hostname ]; then
-		rm -f /etc/hostname;
-	fi
+AUGTOOL="augtool -s --noload --include=/usr/share/createhs/augeas.d"
+AUGTOOL_TPL_HOSTNAME="/usr/share/createhs/augtool.d/set_etc_hostname.augtool.tpl"
+AUGTOOL_TPL_HOSTS="/usr/share/createhs/augtool.d/add_etc_hostname_to_etc_hosts.augtool.tpl"
+
+if [ ! -e /etc/hostname ]; then
+	touch /var/tmp/system-hostname
 fi
 
 if [ -f /etc/default/createhs ]; then
 	. /etc/default/createhs;
 fi
 
-if [ ! -e "/etc/hostname" ]; then
+if [ -e /var/tmp/system-hostname ]; then
 	hostname=""
+	# Compute hostname from mac address
+	#
 	address=( $(ls -1d /sys/class/net/e* /sys/class/net/wlan* 2>/dev/null || true) )
 	if [ ! -z ${address[0]} ]; then
 		mac=`cat ${address[0]}/address | sed s/://g`
 		if [ "$mac" != "" ]; then
-        		hostname="${PREFIX}-${mac}"
+			hostname="${PREFIX}-${mac}"
 		fi
 	fi
-	if [ "$hostname" = "" ]; then
-        	hostname="${PREFIX}-$(tr -cd 'a-f0-9' < /dev/urandom | head -c12)"
+	# If hostname still not set, punt to random
+	#
+	if [ "${hostname}" = "" ]; then
+		hostname="${PREFIX}-$(tr -cd 'a-f0-9' < /dev/urandom | head -c12)"
 	fi
-        echo "Creating /etc/hostname with $hostname"
-        echo "$hostname" > /etc/hostname
-        hostname "$hostname"
-        if ! grep "^127.0.0.1\s*$hostname\s*" /etc/hosts > /dev/null ; then
-            sed -i "1i 127.0.0.1\\t$hostname" /etc/hosts
-        fi
-	rm -f /var/tmp/system-hostname
+	# Did we end up with a hostname?
+	#
+	if [ "${hostname}" != "" ]; then
+		# Update configuration with new hostname
+		#
+		echo "Creating /etc/hostname with ${hostname}"
+		cat "${AUGTOOL_TPL_HOSTNAME}" | \
+		ETC_HOSTNAME="${hostname}"      \
+		envsubst '${ETC_HOSTNAME}'    | \
+		${AUGTOOL}
+		hostname "${hostname}"
+		# Enable update to /etc/hosts
+		#
+		touch /var/tmp/system-hosts
+		# Cleanup
+		#
+		rm -f /var/tmp/system-hostname
+	fi
+fi
 
-	if [ -e /disable-root-fs.wait ]; then
-		mv disable-root-fs.wait disable-root-fs
-		reboot
+# Update /ec/hosts from /etc/hostname?
+#
+if [ -e /var/tmp/system-hosts ]; then
+	# Do we have a hostname to set from:
+	#
+	if [ -e /etc/hostname ]; then
+		echo "Creating hostname entry in /etc/hosts"
+		# Configure and use augeas script to add hostname to /etc/hosts
+		#
+		cat "${AUGTOOL_TPL_HOSTS}"        | \
+		ETC_HOSTNAME=$(cat /etc/hostname)   \
+		envsubst '${ETC_HOSTNAME}'        | \
+		${AUGTOOL}
+		# Cleanup
+		#
+		rm -f /var/tmp/system-hosts
 	fi
+fi
+
+# If we're trying to start as read-only, enable and reboot
+#
+if [ -e /disable-root-fs.wait ]; then
+	mv disable-root-fs.wait disable-root-fs
+	reboot
 fi

--- a/plugins/COMMON/hostname/files/usr/share/createhs/augeas.d/hostname.aug
+++ b/plugins/COMMON/hostname/files/usr/share/createhs/augeas.d/hostname.aug
@@ -1,0 +1,22 @@
+(*
+Module: Hostname
+  Parses /etc/hostname and /etc/mailname
+
+Author: Raphael Pinson <raphink@gmail.com>
+
+About: License
+   This file is licenced under the LGPL v2+, like the rest of Augeas.
+*)
+
+
+module Hostname =
+autoload xfm
+
+(* View: lns *)
+let lns = [ label "hostname" . store Rx.word . Util.eol ] | Util.empty
+
+(* View: filter *)
+let filter = incl "/etc/hostname"
+           . incl "/etc/mailname"
+
+let xfm = transform lns filter

--- a/plugins/COMMON/hostname/files/usr/share/createhs/augtool.d/add_etc_hostname_to_etc_hosts.augtool.tpl
+++ b/plugins/COMMON/hostname/files/usr/share/createhs/augtool.d/add_etc_hostname_to_etc_hosts.augtool.tpl
@@ -1,0 +1,6 @@
+load-file /etc/hosts
+defvar  hosts /files/etc/hosts
+rm      $hosts/*[ipaddr="127.0.1.1"]
+ins     01 after $hosts/*[ipaddr="127.0.0.1"]
+set     $hosts/01/ipaddr "127.0.1.1"
+set     $hosts/01/canonical ${ETC_HOSTNAME}

--- a/plugins/COMMON/hostname/files/usr/share/createhs/augtool.d/set_etc_hostname.augtool.tpl
+++ b/plugins/COMMON/hostname/files/usr/share/createhs/augtool.d/set_etc_hostname.augtool.tpl
@@ -1,0 +1,4 @@
+# augtool -s --noload --include=/usr/share/createhs/augeas.d
+load-file /etc/hostname
+rm  /files/etc/hostname
+set /files/etc/hostname/hostname ${ETC_HOSTNAME}

--- a/plugins/COMMON/hostname/postinst
+++ b/plugins/COMMON/hostname/postinst
@@ -16,7 +16,11 @@ if [ -f "/var/tmp/system-hostname.off" ]; then
 	#
 	rm "/var/tmp/system-hostname.off"
 else
-	# createhs script will run on first boot
+	# Reset hostname on first boot
 	#
 	touch /var/tmp/system-hostname
 fi
+
+# Update /etc/hosts on first boot
+#
+touch /var/tmp/system-hosts

--- a/postinstall
+++ b/postinstall
@@ -150,13 +150,6 @@ else
 	echo "No custom ${DIST} postinst scripts found"
 fi
 
-# If hostname set, add to hosts
-if [ -f /etc/hostname ]; then
-	if ! grep "^127.0.0.1\s*$(cat /etc/hostname)\s*" /etc/hosts > /dev/null; then
-		sed -i "1i 127.0.0.1\\t$(cat /etc/hostname)" /etc/hosts;
-	fi;
-fi
-
 # DFARRELL - Should not be needed, but here in case I'm wrong
 # Finish timezone setup
 #dpkg-reconfigure --frontend noninteractive tzdata

--- a/repos/Debian/multistrap.list.in
+++ b/repos/Debian/multistrap.list.in
@@ -1,6 +1,7 @@
 [Debian]
 packages=base-files base-passwd bash bash-completion bsdutils coreutils dash debconf debconf-i18n debianutils diffutils dpkg e2fslibs e2fsprogs findutils gnupg grep gzip hostname init init-system-helpers initscripts libpam-runtime login lsb-base mawk mount ncurses-base ncurses-bin ncurses-term passwd perl-base sed sensible-utils startpar systemd systemd-sysv sysv-rc sysvinit-utils tar tzdata util-linux zlib1g
 packages=debian-archive-keyring apt apt-utils locales adduser
+packages=augeas-tools augeas-lenses
 source=http://http.debian.net/debian
 keyring=debian-archive-keyring
 components=main contrib non-free

--- a/repos/Raspbian/multistrap.list.in
+++ b/repos/Raspbian/multistrap.list.in
@@ -1,6 +1,7 @@
 [Raspbian]
 packages=base-files base-passwd bash bash-completion bsdutils coreutils dash debconf debconf-i18n debianutils diffutils dpkg e2fslibs e2fsprogs findutils gnupg grep gzip hostname init init-system-helpers initscripts libpam-runtime login lsb-base mawk mount ncurses-base ncurses-bin ncurses-term passwd perl-base sed sensible-utils startpar systemd systemd-sysv sysv-rc sysvinit-utils tar tzdata util-linux zlib1g
 packages=raspbian-archive-keyring apt apt-utils locales adduser
+packages=augeas-tools augeas-lenses
 source=http://mirrordirector.raspbian.org/raspbian
 keyring=raspbian-archive-keyring
 components=main contrib non-free rpi

--- a/repos/Ubuntu/multistrap.list.in
+++ b/repos/Ubuntu/multistrap.list.in
@@ -1,6 +1,7 @@
 [Ubuntu]
 packages=base-files base-passwd bash bash-completion bsdutils coreutils dash debconf debconf-i18n debianutils diffutils dpkg e2fslibs e2fsprogs findutils gnupg grep gzip hostname init init-system-helpers initscripts libpam-runtime login lsb-base mawk mount ncurses-base ncurses-bin ncurses-term passwd perl-base sed sensible-utils startpar systemd systemd-sysv sysv-rc sysvinit-utils tar tzdata util-linux zlib1g
 packages=debian-ports-archive-keyring apt apt-utils locales adduser
+packages=augeas-tools augeas-lenses
 source=http://ports.ubuntu.com/ubuntu-ports
 keyring=debian-ports-archive-keyring
 components=main universe restricted multiverse


### PR DESCRIPTION
Closes https://github.com/BEinControl/be-img-builder-cli/issues/1

For first integration of augeas, I chose the `COMMON/hostname` plugin.

`augtool` turns out not to be able to handle dynamic input, so I came up with a substitution process to pre-process the aug script before passing it to augtool.

I tested these changes locally and by generating a fresh image and confirming changes applied on first boots.

